### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "body-parser": "^1.20.0",
     "express": "^4.18.1",
-    "mongodb": "^6.12.0"
+    "mongodb": "^6.12.0",
+    "express-rate-limit": "^8.2.1"
   },
   "devDependencies": {
     "@playwright/test": "^1.25.1",

--- a/routes/events.js
+++ b/routes/events.js
@@ -1,17 +1,23 @@
 import { Router } from 'express';
+import rateLimit from 'express-rate-limit';
 
 import db from '../data/database.js';
 
 const router = Router();
+
+const eventsRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs for event routes
+});
 
 router.get('/', async (req, res) => {
   const allEvents = await db.collection('events').find().toArray();
   res.json({ events: allEvents });
 });
 
-router.post('/', async (req, res) => {
+router.post('/', eventsRateLimiter, async (req, res) => {
   const eventData = req.body;
-  const result = await db.collection('events').insertOne({...eventData});
+  const result = await db.collection('events').insertOne({ ...eventData });
   res.status(201).json({
     message: 'Event created.',
     event: { ...eventData, id: result.insertedId },


### PR DESCRIPTION
Potential fix for [https://github.com/ReMacod/gh-environment-var-secrets/security/code-scanning/2](https://github.com/ReMacod/gh-environment-var-secrets/security/code-scanning/2)

In general, to fix missing rate limiting on an Express route that accesses the database, add a rate-limiting middleware and apply it to the sensitive route (or router). A well-known library such as `express-rate-limit` should be used rather than implementing custom logic, as it is battle-tested and clear in intent.

For this specific file, the best fix without changing existing functionality is to import `express-rate-limit`, configure a limiter appropriate for the `/events` routes, and then attach it to the POST handler (and optionally the GET handler as well, but the CodeQL alert is for POST). We will:

1. Add an import for `express-rate-limit` at the top of `routes/events.js`.
2. Define a limiter instance, e.g., allowing a bounded number of requests per IP per defined time window.
3. Attach the limiter middleware to the POST route: `router.post('/', eventsLimiter, async (req, res) => { ... });`.

No changes to the logic of handling requests or database interactions are required; we simply insert middleware in the route definition, and define the limiter configuration in the same file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
